### PR TITLE
Value conversion

### DIFF
--- a/lib/mtif/posts.rb
+++ b/lib/mtif/posts.rb
@@ -5,7 +5,7 @@ class MTIF
     attr_accessor :source, :data
   
     SINGLE_VALUE_KEYS = %w(author title status basename date unique_url body extended_body excerpt
-    keywords allow_comments allow_pings convert_breaks no_entry).map(&:to_sym)
+    keywords allow_comments allow_pings convert_breaks no_entry primary_category).map(&:to_sym)
   
     MULTILINE_KEYS = %w(body extended_body excerpt keywords comment ping).map(&:to_sym)
   

--- a/spec/mtif/post_spec.rb
+++ b/spec/mtif/post_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe MTIF::Post do
         "TITLE: Crazy Parents: A Primer\n",
         "DATE: 06/19/1999 07:00:00 PM\n",
         "ALLOW COMMENTS: 0\n",
+        "PRIMARY CATEGORY: Fun!\n",
         "CATEGORY: Fun!\n",
         "-----\n",
         "BODY:\n",


### PR DESCRIPTION
Add primary category

Only convert value if it is single line.
I was face with issue where body contains a line containing numbers. This avoids case of content having a line starting with a number, which force all content to be wrongly converted into integer.

Tighten date conversion condition