### PR TITLE
Add support for comma-separated tags parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 *.gem
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MTIF
 
-A gem to read Movable Type Import Format
+A gem to read Movable Type Import Format, as documented at [TypePad.org](https://movabletype.org/documentation/appendices/import-export-format.html) and also in the [Wayback Machine](https://web.archive.org/web/20210105063407/https://movabletype.org/documentation/appendices/import-export-format.html)
 
 ## Installation
 

--- a/lib/mtif/posts.rb
+++ b/lib/mtif/posts.rb
@@ -8,6 +8,9 @@ class MTIF
     keywords allow_comments allow_pings convert_breaks no_entry primary_category).map(&:to_sym)
     MULTILINE_KEYS = %w(body extended_body excerpt keywords comment ping).map(&:to_sym)
     MULTIVALUE_KEYS = %w(category tag comment ping).map(&:to_sym)
+    MULTIVALUE_KEYS = %w(category tags comment ping).map(&:to_sym)
+
+    CSV_KEYS = %w(tags).map(&:to_sym)
 
     VALID_KEYS = (SINGLE_VALUE_KEYS + MULTILINE_KEYS + MULTIVALUE_KEYS).sort.uniq
 
@@ -63,6 +66,14 @@ class MTIF
       single_line_multivalue_keys.each do |key|
         values = self.send(key)
         next if values.nil? || (values.respond_to?(:empty) && values.empty?)
+
+        if CSV_KEYS.include?(key)
+          values = [
+            values.map{|v|
+              v.include?("\s") ? "\"#{v}\"" : v
+            }.join(',')
+          ]
+        end
 
         values.each do |value|
           result << "#{mtif_key(key)}: #{mtif_value(value)}"
@@ -142,7 +153,13 @@ class MTIF
       value = convert_to_native_type(raw_value)
 
       if MULTIVALUE_KEYS.include?(key)
-        self.data[key] << value unless value.empty?
+        if CSV_KEYS.include?(key)
+          value.split(',').each do |v|
+            self.data[key] << v.gsub(/^\"|\"$/, '') unless v.empty?
+          end
+        else
+          self.data[key] << value unless value.empty?
+        end
       else
         self.data[key] = value
       end

--- a/lib/mtif/posts.rb
+++ b/lib/mtif/posts.rb
@@ -8,7 +8,6 @@ class MTIF
     keywords allow_comments allow_pings convert_breaks no_entry primary_category).map(&:to_sym)
     MULTILINE_KEYS = %w(body extended_body excerpt keywords comment ping).map(&:to_sym)
     MULTIVALUE_KEYS = %w(category tags comment ping).map(&:to_sym)
-
     CSV_KEYS = %w(tags).map(&:to_sym)
 
     VALID_KEYS = (SINGLE_VALUE_KEYS + MULTILINE_KEYS + MULTIVALUE_KEYS).sort.uniq

--- a/lib/mtif/posts.rb
+++ b/lib/mtif/posts.rb
@@ -7,7 +7,6 @@ class MTIF
     SINGLE_VALUE_KEYS = %w(author title status basename date unique_url body extended_body excerpt
     keywords allow_comments allow_pings convert_breaks no_entry primary_category).map(&:to_sym)
     MULTILINE_KEYS = %w(body extended_body excerpt keywords comment ping).map(&:to_sym)
-    MULTIVALUE_KEYS = %w(category tag comment ping).map(&:to_sym)
     MULTIVALUE_KEYS = %w(category tags comment ping).map(&:to_sym)
 
     CSV_KEYS = %w(tags).map(&:to_sym)

--- a/spec/mtif/post_spec.rb
+++ b/spec/mtif/post_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe MTIF::Post do
         "ALLOW COMMENTS: 0\n",
         "PRIMARY CATEGORY: Fun!\n",
         "CATEGORY: Fun!\n",
+        "CATEGORY: More Fun!\n",
         "TAGS: \"Movable Type\",foo,bar\n",
         "-----\n",
         "BODY:\n",
@@ -153,6 +154,10 @@ RSpec.describe MTIF::Post do
       expect(post.body).to eq("Start singing an obnoxious song and ----- never ----- stop.")
     end
     
+    it 'should correctly parse tags as comma-separated values' do
+      expect(post.tags).to eq(["Movable Type","foo","bar"])
+    end
+    
     describe '#method_missing' do
       it 'should properly update values' do
         expect(post.allow_comments).not_to eq(1)
@@ -166,6 +171,20 @@ RSpec.describe MTIF::Post do
       it 'should return concise MTIF containing only keys which are set' do
         # TODO: one day this will break because the hash doesn't join in key order.
         expect(post.to_mtif).to eq(@content.join)
+      end
+      
+      it 'should include updated values' do
+        post.allow_comments = 1
+        expect(post.to_mtif).to match(/ALLOW COMMENTS: 1/)
+      end
+      
+      it 'should convert tags to comma-separated values with proper quoting' do
+        expect(post.to_mtif).to match(/TAGS: "Movable Type",foo,bar/)
+      end
+      
+      it 'should convert categories to multiple CATEGORY lines' do
+        expect(post.to_mtif).to match(/CATEGORY: Fun!/)
+        expect(post.to_mtif).to match(/CATEGORY: More Fun!/)
       end
     end
   end

--- a/spec/mtif/post_spec.rb
+++ b/spec/mtif/post_spec.rb
@@ -115,15 +115,6 @@ RSpec.describe MTIF::Post do
             expect(post.send(key)) == []
           end
         end
-        
-        it 'should default to arrays for multivalue keys' do
-          post = MTIF::Post.new([])
-
-          MTIF::Post::MULTIVALUE_KEYS.each.with_index do |key, i|
-            post.send((key.to_s + '=').to_sym, [i])
-            expect(post.send(key)) == [i]
-          end
-        end
       end
     end
   end

--- a/spec/mtif/post_spec.rb
+++ b/spec/mtif/post_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe MTIF::Post do
       end
     end
   end
-  
+
   context 'parsing input' do
     before :each do
       @content = [
@@ -147,7 +147,20 @@ RSpec.describe MTIF::Post do
       expect(@post.body).to eq("Start singing an obnoxious song and ----- never ----- stop.")
     end
   end
-  
+
+  context 'updating data' do
+    subject {MTIF::Post.new([])}
+    
+    it 'should default to arrays for multivalue keys' do
+      post = MTIF::Post.new([])
+
+      MTIF::Post::MULTIVALUE_KEYS.each.with_index do |key, i|
+        post.send((key.to_s + '=').to_sym, [i])
+        expect(post.send(key)) == [i]
+      end
+    end
+  end
+
   context '#to_mtif' do
     before :each do
       # TODO: refactor to remove ordering dependency
@@ -158,6 +171,7 @@ RSpec.describe MTIF::Post do
         "ALLOW COMMENTS: 0\n",
         "PRIMARY CATEGORY: Fun!\n",
         "CATEGORY: Fun!\n",
+        "TAGS: \"Movable Type\",foo,bar\n",
         "-----\n",
         "BODY:\n",
         "Start singing an obnoxious song and never stop.\n",

--- a/spec/mtif/post_spec.rb
+++ b/spec/mtif/post_spec.rb
@@ -115,10 +115,19 @@ RSpec.describe MTIF::Post do
             expect(post.send(key)) == []
           end
         end
+        
+        it 'should default to arrays for multivalue keys' do
+          post = MTIF::Post.new([])
+
+          MTIF::Post::MULTIVALUE_KEYS.each.with_index do |key, i|
+            post.send((key.to_s + '=').to_sym, [i])
+            expect(post.send(key)) == [i]
+          end
+        end
       end
     end
   end
-  
+
   describe 'instances with content' do
     before :each do
       @content = [
@@ -128,6 +137,7 @@ RSpec.describe MTIF::Post do
         "ALLOW COMMENTS: 0\n",
         "PRIMARY CATEGORY: Fun!\n",
         "CATEGORY: Fun!\n",
+        "TAGS: \"Movable Type\",foo,bar\n",
         "-----\n",
         "BODY:\n",
         "Start singing an obnoxious song and ----- never ----- stop.\n",


### PR DESCRIPTION
@chrome-cgi added this in a branch about a year and a half ago. Picking that up and massaging it a bit.